### PR TITLE
fix: fetch when enabled option changed to true

### DIFF
--- a/lib/src/observer.dart
+++ b/lib/src/observer.dart
@@ -85,8 +85,17 @@ class Observer<TData, TError> extends ChangeNotifier {
   void updateOptions(UseQueryOptions options) {
     final refetchIntervalChanged =
         this.options.refetchInterval != options.refetchInterval;
+    final enabledChanged = this.options.enabled != options.enabled;
 
     _setOptions(options);
+
+    if (enabledChanged) {
+      if (options.enabled == true) {
+        fetch();
+      } else {
+        resolver.cancel();
+      }
+    }
 
     if (options.cacheDuration != null) {
       query.setCacheDuration(options.cacheDuration as Duration);


### PR DESCRIPTION
```dart
final isEnabled = useState(false);

final post = useQuery(
      ['posts'],
      getPosts,
      enabled: isEnabled.value,
)

 useEffect(() {
      // after 5 seconds, isEnabled will be set to true
      Future.delayed(const Duration(seconds: 5), () {
        isEnabled.value = true;
      });
      return () {};
    }, []);
```