### PR TITLE
fix: fetch when enabled option changed to true

### DIFF
--- a/lib/src/hooks/use_query.dart
+++ b/lib/src/hooks/use_query.dart
@@ -125,7 +125,6 @@ UseQueryResult<TData, TError> useQuery<TData, TError>(
     WidgetsBinding.instance.addPostFrameCallback((_) {
       observer.initialize();
     });
-    observer.initialize();
     return () {
       observer.destroy();
     };

--- a/lib/src/hooks/use_query.dart
+++ b/lib/src/hooks/use_query.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:fquery/fquery.dart';

--- a/lib/src/observer.dart
+++ b/lib/src/observer.dart
@@ -85,8 +85,17 @@ class Observer<TData, TError> extends ChangeNotifier {
   void updateOptions(UseQueryOptions options) {
     final refetchIntervalChanged =
         this.options.refetchInterval != options.refetchInterval;
+    final enabledChanged = this.options.enabled != options.enabled;
 
     _setOptions(options);
+
+    if (enabledChanged) {
+      if (options.enabled == true) {
+        fetch();
+      } else {
+        resolver.cancel();
+      }
+    }
 
     if (options.cacheDuration != null) {
       query.setCacheDuration(options.cacheDuration as Duration);


### PR DESCRIPTION
```dart
final isEnabled = useState(false);

final post = useQuery(
      ['posts'],
      getPosts,
      enabled: isEnabled.value,
)

 useEffect(() {
      // after 5 seconds, isEnabled will be set to true
      Future.delayed(const Duration(seconds: 5), () {
        isEnabled.value = true;
      });
      return () {};
    }, []);
```